### PR TITLE
Add node previewing

### DIFF
--- a/consult-org-roam.el
+++ b/consult-org-roam.el
@@ -156,34 +156,10 @@ defaulting to \"Node: \""
     (if (org-roam-node-p node) (progn node)
       (progn (org-roam-node-create :title node)))))
 
-(defun consult-org-roam--buffer-preview ()
-  "Function to preview an org-roam-node."
-  ;; Only preview in current window and other window.
-  ;; Preview in frames and tabs is not possible since these don't get cleaned up.
-  (if (memq consult--buffer-display
-            '(switch-to-buffer switch-to-buffer-other-window))
-      (let ((orig-buf (current-buffer)) other-win)
-        (lambda (action cand point)
-          (when (eq action 'preview)
-            (when (and (eq consult--buffer-display #'switch-to-buffer-other-window)
-                       (not other-win))
-              (switch-to-buffer-other-window orig-buf)
-              (setq other-win (selected-window)))
-            (let ((win (or other-win (selected-window))))
-              (when (window-live-p win)
-                (with-selected-window win
-                  (cond
-                   ((and cand (get-buffer cand))
-                    (switch-to-buffer cand 'norecord)
-                    (set-window-start win point))
-                   ((buffer-live-p orig-buf)
-                    (switch-to-buffer orig-buf 'norecord)))))))))
-    #'ignore))
-
 (defun consult-org-roam--node-preview ()
   "Create preview function for nodes."
   (let ((open (consult--temporary-files))
-        (preview (consult-org-roam--buffer-preview)))
+        (preview (consult--buffer-preview)))
     (lambda (action cand)
       (when (eq action 'exit)
         (funcall open))
@@ -191,8 +167,10 @@ defaulting to \"Node: \""
           (funcall preview action
                    (and cand
                         (eq action 'preview)
-                        (funcall open (org-roam-node-file cand)))
-                   (org-roam-node-point cand))))))
+                        (set-window-start
+                         (selected-window)
+                         (org-roam-node-point cand))
+                        (funcall open (org-roam-node-file cand))))))))
 
 ;; Completing-read interface for references using consult. Override
 ;; `org-roam-ref-read' so that each an every completing function

--- a/consult-org-roam.el
+++ b/consult-org-roam.el
@@ -78,16 +78,21 @@ supplied. Can take a PROMPT argument."
   "Select from list of all notes that link to the current note."
   (interactive)
   (let* ((node (org-roam-node-at-point))
-         (ids (org-roam-db-query
+         (ids (mapcar (lambda (el) (car el))(org-roam-db-query
             [:select [source]
                      :from links
                      :where (= dest $s1)
                      :and (= type "id")]
             (if node
                 (org-roam-node-id (org-roam-node-at-point))
-              (user-error "Buffer does not contain org-roam-nodes")))))
+              (user-error "Buffer does not contain org-roam-nodes"))))))
     (if ids
-        (find-file (consult-org-roam--select-file "Backlinks: " (consult-org-roam--ids-to-files ids)))
+        (org-roam-node-read ""
+                            (lambda (n)
+                              (if (org-roam-node-p n)
+                                  (if (member (org-roam-node-id n) ids)
+                                      t
+                                    nil))))
       (user-error "No backlinks found"))))
 
 ;;;###autoload
@@ -126,7 +131,7 @@ for an example sort function.
 If REQUIRE-MATCH, the minibuffer prompt will require a match.
 PROMPT is a string to show at the beginning of the mini-buffer,
 defaulting to \"Node: \""
-  (let* ((nodes (org-roam-node-read--completions filter-fn sort-fn))
+  (let* ((nodes (org-roam-node-read--completions filter-fn sort-fn)) ;;
          (prompt (or prompt "Node: "))
          ;; Sets state-func only when there are nodes to avoid errors
          ;; with empty roam-dirs
@@ -137,7 +142,7 @@ defaulting to \"Node: \""
            nodes
            :prompt prompt
            :initial initial-input
-           :predicate filter-fn
+           ;;:predicate filter-fn ;; has a different structure than org-roam's filter func
            :sort sort-fn
            :require-match require-match
            :category 'org-roam-node

--- a/readme.org
+++ b/readme.org
@@ -5,6 +5,9 @@
 #+html: <a href="https://www.gnu.org/software/emacs/"><img alt="GNU Emacs" src="https://github.com/minad/corfu/blob/screenshots/emacs.svg?raw=true"/></a>
 #+html: <a href="https://melpa.org/#/consult-org-roam"><img alt="MELPA" src="https://melpa.org/packages/consult-org-roam-badge.svg"/></a>
 
+This is a collection of functions to operate [[https://github.com/org-roam/org-roam][org-roam]] with the help of
+[[https://github.com/minad/consult][consult]] and its live preview feature.
+
 * Overview and usage
 =consult-org-roam.el= provides several functions to connect [[https://github.com/org-roam/org-roam][org-roam]]
 to [[https://github.com/minad/consult][consult]]'s completing read interface. On the one hand, it provides

--- a/readme.org
+++ b/readme.org
@@ -1,10 +1,13 @@
-* =consult-org-roam= -- An Unofficial Extension
-This is a small collection of functions to operate [[https://github.com/org-roam/org-roam][org-roam]] with the
-help of [[https://github.com/minad/consult][consult]] and its live preview feature.
+#+title: =consult-org-roam=
+#+author: jgru
+#+language: en
+
+#+html: <a href="https://www.gnu.org/software/emacs/"><img alt="GNU Emacs" src="https://github.com/minad/corfu/blob/screenshots/emacs.svg?raw=true"/></a>
+#+html: <a href="https://melpa.org/#/consult-org-roam"><img alt="MELPA" src="https://melpa.org/packages/consult-org-roam-badge.svg"/></a>
 
 * Overview and usage
-=consult-org-roam.el= provides several functions to connect org-roam
-to consult's completing read interface. On the one hand, it provides
+=consult-org-roam.el= provides several functions to connect [[https://github.com/org-roam/org-roam][org-roam]]
+to [[https://github.com/minad/consult][consult]]'s completing read interface. On the one hand, it provides
 the following standalone functions which enhance =org-roam='s
 capabilities:
 
@@ -13,6 +16,8 @@ capabilities:
 - =consult-org-roam-backlinks= :: List backlinks to
   =org-roam-node-at-point= (e.g. currently open note) and sift through
   them with consult's completing-read and its live preview
+- =consult-org-roam-forward-links :: List forward links contained in
+  the currently opened note
 - =consult-org-roam-file-find= :: Search your org-roam files with
   consult's completing-read and its live preview
 
@@ -29,10 +34,10 @@ functions. This can be done by adding using
 =consult-customize=.
 
 * Installation
-
+Install it from Melpa
 #+begin_src elisp
 (use-package consult-org-roam
-   :straight (:host github :repo "jgru/consult-org-roam")
+   :ensure t
    :init
    (require 'consult-org-roam)
    ;; Activate the minor-mode


### PR DESCRIPTION
This PR adds the capability to preview single nodes. 
In order to achieve this functionality, `window-start` of the housing buffer is moved to the line of the node in questions.