### PR TITLE
Make consult-org-roam minor-mode global

### DIFF
--- a/consult-org-roam.el
+++ b/consult-org-roam.el
@@ -199,6 +199,7 @@ filtered out."
 By enabling `consult-org-roam-mode' the functions `org-roam-node-read' and
 `org-roam-ref-read' are overriden by consults-org-roam's equivalents. Optional
 argument ARG indicates whether the mode should be enabled or disabled."
+  :global t
   :lighter " cor"
   ;; Add or remove advice when enabled respectively disabled
   (if consult-org-roam-mode


### PR DESCRIPTION
The advices that it creates are not limited to a single buffer, but to the whole emacs sessions, so it should be a global minor mode if I'm not thinking wrong. The only exception would be if you to use the minor-mode as a buffer-specific mode hook, e.g.

``` emacs-lisp
(add-hook 'org-mode-hook #'consult-org-roam-mode)
```

then it might be useful to have the mode local, but then I you would need to think about making the advices somehow local (I don't know if that works).