### PR TITLE
Autoload the consult-org-roam-search command

### DIFF
--- a/consult-org-roam.el
+++ b/consult-org-roam.el
@@ -44,6 +44,7 @@
 ;;;; Functions
 ;; ============================================================================
 
+;;;###autoload
 (defun consult-org-roam-search (&optional initial)
   "Search org-roam directory using `consult-ripgrep' with live-preview.
 With an option for INITIAL input when called non-interactively."


### PR DESCRIPTION
The `consult-org-roam-search` command doesn't have an autoload comment, unlike the other interactive commands.

However, it's a reasonable entry point to this package (or indeed, to the whole of Org-roam).

To autoload the command I need to declare the command using the `:commands` or `:bind` keywords for `use-package`. I also don't want to load this package until after Org-roam, so I have this convoluted set-up:

```
(use-package consult-org-roam
  :commands (consult-org-roam-search)
  :config
  (consult-org-roam-mode t)
  :init
  (with-eval-after-load 'org-roam
    (require 'consult-org-roam))
  :straight t)
```

I'd prefer to use `:after org-roam`, but then the `:commands` won't work.

If the command had an autoload comment, the set-up would be simpler:

```
(use-package consult-org-roam
  :after org-roam
  :config
  (consult-org-roam-mode t)
  :straight t)
```
