### PR TITLE
Remove dependency on f.el

### DIFF
--- a/consult-org-roam-buffer.el
+++ b/consult-org-roam-buffer.el
@@ -138,9 +138,9 @@ title of an open org-roam buffer."
      :narrow   ,consult-org-roam-buffer-narrow-key
      :category org-roam-buffer
      :annotate ,(lambda (cand)
-                  (file-name-nondirectory (directory-file-name
+                  (file-name-nondirectory
                     (buffer-name
-                      (consult-org-roam-buffer--with-title cand)))))
+                      (consult-org-roam-buffer--with-title cand))))
      :state    ,#'consult-org-roam-buffer--state
      :items    ,#'consult-org-roam-buffer--get-roam-bufs))
 

--- a/consult-org-roam-buffer.el
+++ b/consult-org-roam-buffer.el
@@ -21,7 +21,6 @@
 
 (require 'org-roam)
 (require 'consult)
-(require 'f)
 
 ;; ============================================================================
 ;;;; Customize definitions
@@ -139,9 +138,9 @@ title of an open org-roam buffer."
      :narrow   ,consult-org-roam-buffer-narrow-key
      :category org-roam-buffer
      :annotate ,(lambda (cand)
-                  (f-filename
+                  (file-name-nondirectory (directory-file-name
                     (buffer-name
-                      (consult-org-roam-buffer--with-title cand))))
+                      (consult-org-roam-buffer--with-title cand)))))
      :state    ,#'consult-org-roam-buffer--state
      :items    ,#'consult-org-roam-buffer--get-roam-bufs))
 


### PR DESCRIPTION
`org-roam` removed the dependency on f.el recently and since consult-org-roam doesn't declare this as a dependency in `Package-Requires`, it breaks on re-compilation.

I looked at what was being used from f.el and it looked like an easy replacement. Haven't done a bunch of testing but appears to be working locally.