### PR TITLE
Fix order of org-roam-buffers

### DIFF
--- a/consult-org-roam-buffer.el
+++ b/consult-org-roam-buffer.el
@@ -160,9 +160,9 @@ consult--source-buffer."
   (if consult-org-roam-buffer-after-buffers
     (let* ((idx (cl-position 'consult--source-buffer
                   consult-buffer-sources :test 'equal))
-            (tail (nthcdr idx consult-buffer-sources)))
+            (tail (nthcdr (1+ idx) consult-buffer-sources)))
       (setcdr
-        (nthcdr (1- idx) consult-buffer-sources)
+        (nthcdr idx consult-buffer-sources)
         (append (list 'org-roam-buffer-source) tail)))
     (add-to-list 'consult-buffer-sources 'org-roam-buffer-source 'append)))
 


### PR DESCRIPTION
Fixes #27.

With `consult-org-roam-buffer-after-buffers` enabled, the order of buffers is now: `(consult--source-hidden-buffer consult--source-modified-buffer consult--source-buffer org-roam-buffer-source consult--source-recent-file consult--source-file-register consult--source-bookmark consult--source-project-buffer-hidden consult--source-project-recent-file-hidden)`