### PR TITLE
Change buffer name retrieval to use file name

### DIFF
--- a/consult-org-roam-buffer.el
+++ b/consult-org-roam-buffer.el
@@ -69,7 +69,7 @@
     (let* ((title
              (with-current-buffer buffer
                (org-roam-db--file-title)))
-            (bufname (buffer-name buffer))
+            (bufname (buffer-file-name buffer))
             (fhash (consult-org-roam-db--file-hash bufname)))
       (if fhash
         (progn


### PR DESCRIPTION
If 2 directories have the same note file name (eg foo/index.org and spam/index.org), the buffer names will be like "index.org\<foo\>" and cause problem.