### PR TITLE
Moved mode init to :config and removed redundant require in readme.org

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -57,10 +57,6 @@ snippet might serve as a viable starting point:
 (use-package consult-org-roam
    :ensure t
    :after org-roam
-   :init
-   (require 'consult-org-roam)
-   ;; Activate the minor mode
-   (consult-org-roam-mode 1)
    :custom
    ;; Use `ripgrep' for searching with `consult-org-roam-search'
    (consult-org-roam-grep-func #'consult-ripgrep)
@@ -74,6 +70,8 @@ snippet might serve as a viable starting point:
    (consult-customize
     consult-org-roam-forward-links
     :preview-key "M-.")
+   ;; Activate the minor mode
+   (consult-org-roam-mode 1)
    :bind
    ;; Define some convenient keybindings as an addition
    ("C-c n e" . consult-org-roam-file-find)


### PR DESCRIPTION
I ran into a few issues when setting up the use-package def provided in the `readme.org`.

1. `(require 'consult-org-roam)` should be removed from `:init` as it is unnecessary inside the package's own `use-package` block.
2.  `(consult-org-roam-mode 1)` should be moved from `:init` to `:config` so it runs after the package has loaded.

Thanks for the project :)